### PR TITLE
Indexing TowerCache - Fix Indexing Nil Value Error

### DIFF
--- a/sonorancad/submodules/sonrad/sv_sonrad.lua
+++ b/sonorancad/submodules/sonrad/sv_sonrad.lua
@@ -142,7 +142,7 @@ CreateThread(function() Config.LoadPlugin("sonrad", function(pluginConfig)
                     debugLog(json.encode(TowerCache))
                     for _,t in ipairs(TowerCache) do
 
-                        if TowerCache[t].NotPhysical then
+                        if t.NotPhysical then
                             -- Handling for Mobile Repeaters
                             title = "Mobile Repeater"
                             color = "#ff00f6"


### PR DESCRIPTION
Hi, our console was spamming a stack trace every time a player connected, something about the Sonoran Radio integration submodule indexing a nil value. I looked at the code and saw it was indexing the value instead of the key. I haven't tested this fully, other than it preventing the stack trace, but I believe it shouldn't cause further issues. I'll have to wait until tomorrow when the server gets active again to see if any problems remain with the integration.