### PR TITLE
Added json glob in submodules/postals

### DIFF
--- a/sonorancad/fxmanifest.lua
+++ b/sonorancad/fxmanifest.lua
@@ -43,7 +43,8 @@ files {
     'core/client_nui/js/*.js',
     'core/client_nui/sounds/*.mp3',
     'core/client_nui/img/logo.gif',
-    'submodules/**/*.mp3'
+    'submodules/**/*.mp3',
+    'submodules/postals/*.json'
 }
 
 data_file 'DLC_ITYP_REQUEST' 'stream/**/*.ytyp'


### PR DESCRIPTION
added a globbed json getter to the files section in the manifest in submodules/postals for use of the 'file' config for getting postals.