### PR TITLE
Print non-debug logs when debugging

### DIFF
--- a/sonorancad/core/logging.lua
+++ b/sonorancad/core/logging.lua
@@ -50,7 +50,7 @@ local function sendConsole(level, color, message)
         source = info.source:gsub("@@sonorancad/","")..":"..info.linedefined
     end
     local msg = ("[%s][%s:%s%s^7]%s %s^0"):format(time, debugging and source or "SonoranCAD", color, level, color, message)
-    if (debugging and level == "DEBUG") or (not debugging and level ~= "DEBUG") then
+    if (debugging and level == "DEBUG") or level ~= "DEBUG" then
         print(msg)
     end
     if (level == "ERROR" or level == "WARNING") and IsDuplicityVersion() then


### PR DESCRIPTION
This PR updates the logic of the `sendConsole` function such that when debugging is enabled, non-debug messages are logged to the console. The current behaviour appears to be accidental, and only allows for printing of debug messages when debug is enabled.