### PR TITLE
Improve custom submodules loading

### DIFF
--- a/sonorancad/core/plugin_loader.lua
+++ b/sonorancad/core/plugin_loader.lua
@@ -17,16 +17,13 @@ local function LoadVersionFile()
 end
 
 function CheckForPluginUpdate(name)
+    local check_url = 'https://raw.githubusercontent.com/Sonoran-Software/SonoranCADFiveM/refs/heads/master/sonorancad/version.json'
     local plugin = Config.plugins[name]
-    plugin.check_url = 'https://raw.githubusercontent.com/Sonoran-Software/SonoranCADFiveM/refs/heads/master/sonorancad/version.json'
     if plugin == nil then
         errorLog(("Submodule %s not found."):format(name))
         return
-    elseif plugin.check_url == nil or plugin.check_url == "" then
-        debugLog(("Submodule %s does not have check_url set. Is it configured correctly?"):format(name))
-        return
     end
-    PerformHttpRequestS(plugin.check_url, function(code, data, headers)
+    PerformHttpRequestS(check_url, function(code, data, headers)
         if code == 200 then
             local remote = json.decode(data)
             if remote == nil then

--- a/sonorancad/core/plugin_loader.lua
+++ b/sonorancad/core/plugin_loader.lua
@@ -61,6 +61,11 @@ function CheckForPluginUpdate(name)
                         local filePath = ("%s/configuration/config-backup"):format(GetResourcePath(GetCurrentResourceName()))
                         exports['sonorancad']:CreateFolderIfNotExisting(filePath)
                         local backupFile = io.open(("%s/configuration/config-backup/%s_config.lua"):format(GetResourcePath(GetCurrentResourceName()), name), "w")
+                        if backupFile == nil then
+                            errorLog(("Unable to open config backup file for sub module %s."):format(name))
+                            return
+                        end
+
                         backupFile:write(distConfig)
                         backupFile:close()
                         os.remove(("%s/configuration/%s_config.dist.lua"):format(GetResourcePath(GetCurrentResourceName()), name))

--- a/sonorancad/core/plugin_loader.lua
+++ b/sonorancad/core/plugin_loader.lua
@@ -102,7 +102,7 @@ CreateThread(function()
         end
         local versionFile = json.decode(vfile)
         if Config.plugins[k].enabled then
-            if versionFile.submoduleConfigs[k].requiresPlugins ~= nil then
+            if versionFile.submoduleConfigs[k] ~= nil and versionFile.submoduleConfigs[k].requiresPlugins ~= nil then
                 for _, plugin in pairs(versionFile.submoduleConfigs[k].requiresPlugins) do
                     local isCritical = plugin.critical
                     if Config.plugins[plugin.name] == nil or not Config.plugins[plugin.name].enabled then

--- a/sonorancad/core/plugin_loader.lua
+++ b/sonorancad/core/plugin_loader.lua
@@ -9,7 +9,7 @@
 local function LoadVersionFile()
     local f = LoadResourceFile(GetCurrentResourceName(), ("version.json"))
     if f then
-    return f
+        return f
     else
         warnLog(("Failed to load version file from /sonorancad/version.json Check to see if the file exists."))
         return nil
@@ -28,11 +28,15 @@ function CheckForPluginUpdate(name)
             local remote = json.decode(data)
             if remote == nil then
                 if plugin.enabled then
-                    warnLog(("Failed to get a valid response for %s. Skipping."):format(k))
-                    debugLog(("Raw output for %s: %s"):format(k, data))
+                    warnLog(("Failed to get a valid response for %s. Skipping."):format(name))
                 end
-            elseif remote.submoduleConfigs[name] == nil and plugin.enabled then
-                warnLog(("Failed to check submodule updates for %s: submodule was not found in the updater manifest... if this is a custom submodule you can ignore this warning"):format(name))
+                debugLog(("Raw output for %s request to %s: %s"):format(name, check_url, data))
+            elseif remote.submoduleConfigs[name] == nil then
+                if plugin.enabled then
+                    warnLog(("Failed to check submodule updates for %s: submodule was not found in the updater manifest... if this is a custom submodule you can ignore this warning"):format(name))
+                else
+                    debugLog(("Disabled submodule was not found in remote updater manifest: %s"):format(name))
+                end
             elseif (remote.submoduleConfigs[name].version == nil) then
                 warnLog(("Submodule was found, but no version was found in remote updater manifest for plugin %s."):format(name))
             else

--- a/sonorancad/core/plugin_loader.lua
+++ b/sonorancad/core/plugin_loader.lua
@@ -74,17 +74,25 @@ CreateThread(function()
     Wait(5000)
     while Config.apiVersion == -1 do Wait(10) end
     if Config.critError then logError("ERROR_ABORT") end
+
+    local versionFile = nil
+    local vfile = LoadVersionFile()
+    if vfile == nil then
+        warnLog("Unable to load local plugin version file")
+        goto skip
+    end
+    versionFile = json.decode(vfile)
+    if versionFile == nil then
+        warnLog("Unable to parse local plugin version file")
+        goto skip
+    end
+
     for k, v in pairs(Config.plugins) do
         if Config.critError then
             Config.plugins[k].enabled = false
             Config.plugins[k].disableReason = "Startup aborted"
             goto skip
         end
-        local vfile = LoadVersionFile(k)
-        if vfile == nil then
-            goto skip
-        end
-        local versionFile = json.decode(vfile)
         if Config.plugins[k].enabled then
             if versionFile.submoduleConfigs[k] ~= nil and versionFile.submoduleConfigs[k].requiresPlugins ~= nil then
                 for _, plugin in pairs(versionFile.submoduleConfigs[k].requiresPlugins) do


### PR DESCRIPTION
Fixes an issue in the plugin loader/update function that will make custom submodules load properly when not beeing present in the local or remote `version.json` file. Also added some additional nil checks to make sure everything runs smoothly 🍞.