### PR TITLE
Add missing push event handlers

### DIFF
--- a/sonorancad/core/httpd.lua
+++ b/sonorancad/core/httpd.lua
@@ -258,6 +258,10 @@ local PushEventHandler = {
 	EVENT_TONE = function(body)
 		TriggerEvent('SonoranCAD::pushevents:Tone', body.data)
 		return true
+	end,
+	EVENT_CHAR_SELECTED = function(body)
+		TriggerEvent('SonoranCAD::pushevents:CharacterSelected', body.data)
+		return true
 	end
 }
 

--- a/sonorancad/core/httpd.lua
+++ b/sonorancad/core/httpd.lua
@@ -251,6 +251,10 @@ local PushEventHandler = {
 		TriggerEvent('SonoranCAD::pushevents:UnitGroupRemove', body.data)
 		return true
 	end,
+	EVENT_UNIT_GROUP_CHANGE_NAME = function(body)
+		TriggerEvent('SonoranCAD::pushevents:UnitGroupRename', body.data)
+		return true
+	end,
 	EVENT_TONE = function(body)
 		TriggerEvent('SonoranCAD::pushevents:Tone', body.data)
 		return true


### PR DESCRIPTION
Adding missing event handlers:
 - `EVENT_CHAR_SELECTED`: https://info.sonorancad.com/sonoran-cad/api-integration/push-events/civilian/character-selected
 - `EVENT_UNIT_GROUP_CHANGE_NAME`: https://info.sonorancad.com/sonoran-cad/api-integration/push-events/unit-events/unit-group-name-change