### PR TITLE
fix(sonorancad): createDispatchCall data un-nesting

### DIFF
--- a/sonorancad/core/server.lua
+++ b/sonorancad/core/server.lua
@@ -413,30 +413,26 @@ call911 = function(caller, location, description, postal, plate, cb, coords, cus
 end
 
 createDispatchCall = function(origin, status, priority, block, address, postal, title, code, primary, trackPrimary, description, notes, metaData, units, cb)
-    local dispatchData = {
-        serverId = GetConvar('sonoran_serverId', 1),
-        origin = origin or 0,
-        status = status or 0,
-        priority = priority or 1,
-        block = block or "",
-        address = address or "",
-        postal = postal or "",
-        title = title or "New Call",
-        code = code or "",
-        primary = primary or 0,
-        trackPrimary = trackPrimary == nil and false or trackPrimary,
-        description = description or "",
-        notes = notes or {},         -- expects array of note objects if any
-        metaData = metaData or {},   -- optional extra metadata
-        units = units or {}          -- expects array of unit Steam IDs or similar
-    }
-
     exports['sonorancad']:performApiRequest({
         {
             id = GetConvar("sonoran_community_id", "YOUR_COMMUNITY_ID"),
             key = GetConvar("sonoran_api_key", "YOUR_API_KEY"),
             type = "NEW_DISPATCH",
-            data = { dispatchData }
+            serverId = GetConvar('sonoran_serverId', 1),
+            origin = origin or 0,
+            status = status or 0,
+            priority = priority or 1,
+            block = block or "",
+            address = address or "",
+            postal = postal or "",
+            title = title or "New Call",
+            code = code or "",
+            primary = primary or 0,
+            trackPrimary = trackPrimary == nil and false or trackPrimary,
+            description = description or "",
+            notes = notes or {},         -- expects array of note objects if any
+            metaData = metaData or {},   -- optional extra metadata
+            units = units or {}          -- expects array of unit Steam IDs or similar
         }
     }, "NEW_DISPATCH", cb)
 end


### PR DESCRIPTION
The `NEW_DISPATCH` API endpoint is expecting data to be at the top level of the data payload. This change removes the data from a nested `data` array and moves it to the top level to prevent missing field errors when attempting to call this export. 

I believe this error stems from the API end, which appears does not follow the format on the docs (which has the call data nested, and not alongside the `id`, `key`, and `type`). So, it may be better to look at the API code instead to confirm it is looking for the data in the proper place.