### PR TITLE
feat(tablet): new functionality for frameworks

### DIFF
--- a/tablet/config.lua
+++ b/tablet/config.lua
@@ -1,0 +1,29 @@
+Config = {}
+
+Config.Framework = "qb" -- qb, esx, auto
+
+Config.AutoHideOnVehicleExit = true -- if true, the cad will automatically hide when the player exits a vehicle
+Config.AllowMiniCadOnFoot = false -- if true, player can access the cad while on foot
+
+Config.AccessRestrictions = {
+    RequireTabletItem = true, -- if true, player must have the tablet item to access the cad
+    TabletItemName = "sonorantablet", -- name of the tablet item
+    RestrictByJob = true, -- if true, player must have a job in the allowed jobs list to access the cad
+    RestrictByVehicle = false, -- if true, player must be in a vehicle in the allowed vehicles list to access the cad
+    AllowedJobs = {
+        "lspd",
+        "sheriff",
+        "ambulance",
+        "fire"
+    },
+    AllowedVehicles = {
+        "police",
+        "police2",
+        "police3",
+        "police4",
+        "fbi",
+        "fbi2",
+        "ambulance",
+        "firetruk"
+    }
+}

--- a/tablet/fxmanifest.lua
+++ b/tablet/fxmanifest.lua
@@ -4,6 +4,10 @@ games {'gta5'}
 
 ui_page 'html/index.html'
 
+shared_scripts {
+    'config.lua'
+}
+
 server_scripts {
     'sv_main.lua'
 }
@@ -17,5 +21,6 @@ files {
     'html/index.html',
     'html/style.css',
     'html/reset.css',
-    "html/script.js"
+    "html/script.js",
+    "html/tablet.png"
 }

--- a/tablet/html/index.html
+++ b/tablet/html/index.html
@@ -9,6 +9,9 @@
         <div id="cadDiv" style="display:none;">
             <div class="content">
 				<div id="check-api-data" style="display:none">API ID not found! Please login into your Sonoran CAD account to get your API ID set. - <button id="retryapi" name="retryapi" value="Retry" onclick="runApiCheck()">Retry</button></div>
+                <div id="homeButton"></div>
+                <div id="tabletCamera"></div>
+
                 <!-- Edit the src field below with your custom link, if used. You can also resize the tablet frame.-->
                 <iframe id="cadFrame" src="https://sonorancad.com/" width="1100" height="510"></iframe>
             </div>

--- a/tablet/html/script.js
+++ b/tablet/html/script.js
@@ -216,7 +216,6 @@ $(function () {
 			switch (event.data.key) {
 				case 'maxrows':
 					maxrows = event.data.value;
-					console.log("Rows set to " + event.data.value);
 					refreshCall();
 					break;
 				default:
@@ -383,3 +382,7 @@ function runApiCheck() {
 	$.post('https://tablet/runApiCheck');
 	$("#check-api-data").hide();
 }
+
+document.getElementById('homeButton').addEventListener('click', function() {
+	$.post('https://tablet/NUIFocusOff', JSON.stringify({}));
+});

--- a/tablet/html/script.js
+++ b/tablet/html/script.js
@@ -216,6 +216,7 @@ $(function () {
 			switch (event.data.key) {
 				case 'maxrows':
 					maxrows = event.data.value;
+					console.log("Rows set to " + event.data.value);
 					refreshCall();
 					break;
 				default:
@@ -317,11 +318,54 @@ $(function () {
 	dragElement(document.getElementById("cadDiv"));
 	dragElement(document.getElementById("hudDiv"));
 
+	document.addEventListener('mousedown', function(e) {
+		const draggingElements = document.querySelectorAll('.dragging');
+		if (draggingElements.length > 0) {
+			const cadFrame = document.getElementById('cadFrame');
+			if (cadFrame && (cadFrame === e.target || cadFrame.contains(e.target))) {
+				e.preventDefault();
+				e.stopPropagation();
+				return false;
+			}
+		}
+	}, true);
+	
+	document.addEventListener('mouseover', function(e) {
+		const draggingElements = document.querySelectorAll('.dragging');
+		if (draggingElements.length > 0) {
+			const cadFrame = document.getElementById('cadFrame');
+			if (cadFrame && (cadFrame === e.target || cadFrame.contains(e.target))) {
+				e.preventDefault();
+				e.stopPropagation();
+			}
+		}
+	}, true);
+
 	window.addEventListener("message", receiveMessage, false);
+	
+	window.addEventListener('blur', function() {
+		const draggingElements = document.querySelectorAll('.dragging');
+		if (draggingElements.length > 0) {
+			draggingElements.forEach(function(element) {
+				element.classList.remove('dragging');
+			});
+			const overlay = document.getElementById('dragOverlay');
+			if (overlay) {
+				overlay.parentNode.removeChild(overlay);
+			}
+			const cadFrame = document.getElementById('cadFrame');
+			if (cadFrame) {
+				cadFrame.style.pointerEvents = 'auto';
+			}
+		}
+	});
 });
 
 function dragElement(elmnt) {
 	var pos1 = 0, pos2 = 0, pos3 = 0, pos4 = 0;
+	var isDragging = false;
+	var dragOverlay = null;
+	
 	if (document.getElementById(elmnt.id + "header")) {
 		// if present, the header is where you move the DIV from:
 		document.getElementById(elmnt.id + "header").onmousedown = dragMouseDown;
@@ -333,9 +377,17 @@ function dragElement(elmnt) {
 	function dragMouseDown(e) {
 		e = e || window.event;
 		e.preventDefault();
+		e.stopPropagation();
+		
 		// get the mouse cursor position at startup:
 		pos3 = e.clientX;
 		pos4 = e.clientY;
+		isDragging = true;
+		
+		elmnt.classList.add('dragging');
+		
+		createDragOverlay();
+		
 		document.onmouseup = closeDragElement;
 		// call a function whenever the cursor moves:
 		document.onmousemove = elementDrag;
@@ -344,6 +396,10 @@ function dragElement(elmnt) {
 	function elementDrag(e) {
 		e = e || window.event;
 		e.preventDefault();
+		e.stopPropagation();
+		
+		if (!isDragging) return;
+		
 		// calculate the new cursor position:
 		pos1 = pos3 - e.clientX;
 		pos2 = pos4 - e.clientY;
@@ -356,8 +412,48 @@ function dragElement(elmnt) {
 
 	function closeDragElement() {
 		// stop moving when mouse button is released:
+		isDragging = false;
+		elmnt.classList.remove('dragging');
+		removeDragOverlay();
 		document.onmouseup = null;
 		document.onmousemove = null;
+	}
+	
+	function createDragOverlay() {
+		removeDragOverlay();
+		
+		dragOverlay = document.createElement('div');
+		dragOverlay.id = 'dragOverlay';
+		dragOverlay.style.cssText = `
+			position: fixed;
+			top: 0;
+			left: 0;
+			width: 100%;
+			height: 100%;
+			background: transparent;
+			z-index: 9998;
+			pointer-events: none;
+		`;
+		document.body.appendChild(dragOverlay);
+		
+		const cadFrame = document.getElementById('cadFrame');
+		if (cadFrame) {
+			cadFrame.style.pointerEvents = 'none';
+		}
+	}
+	
+	function removeDragOverlay() {
+		if (dragOverlay) {
+			if (dragOverlay.parentNode) {
+				dragOverlay.parentNode.removeChild(dragOverlay);
+			}
+			dragOverlay = null;
+		}
+		
+		const cadFrame = document.getElementById('cadFrame');
+		if (cadFrame) {
+			cadFrame.style.pointerEvents = 'auto';
+		}
 	}
 }
 

--- a/tablet/html/style.css
+++ b/tablet/html/style.css
@@ -2,200 +2,444 @@
 /* Tablet Device */
 #cadDiv {
 	position: absolute;
-	top: 25%;
+	top: 5%;
 	left: 50%;
 	transform: translate(-50%, 0);
-	width: 1100px;
-	height: 525px;
+	width: 1200px;
+	height: 900px;
+	border: 20px solid #1a1a1a;
+	border-top-width: 35px;
+	border-bottom-width: 35px;
+	border-radius: 35px;
+	background: #2c2c2c;
+	transition: all 0.3s ease;
+	box-shadow: 
+		0 4px 16px rgba(0, 0, 0, 0.2),
+		0 2px 8px rgba(0, 0, 0, 0.1);
+}
 
-	border: 20px black solid;
-	border-top-width: 25px;
-	border-bottom-width: 25px;
-	border-radius: 15px;
-	background: black;
+#cadDiv:before {
+	content: '';
+	position: absolute;
+	top: -35px;
+	left: -20px;
+	right: -20px;
+	bottom: -35px;
+	border-radius: 35px;
+	background: #1a1a1a;
+	pointer-events: none;
+	z-index: -1;
 }
-.cadDiv .content {
-	margin-left: 37%;
-	margin-bottom: 15%;
-	margin-top: 10%;
-	border: 5px;
-	border-color: yellow
-	
+
+#tabletCamera {
+	position: absolute;
+	top: -22px;
+	left: 50%;
+	transform: translateX(-50%);
+	width: 10px;
+	height: 10px;
+	background: #404040;
+	border-radius: 50%;
+	border: 1px solid #2c2c2c;
+	box-shadow: 
+		0 0 0 1px rgba(0, 0, 0, 0.3),
+		inset 0 0 2px 1px rgba(0, 0, 0, 0.5);
 }
+
+#tabletCamera:after {
+	content: '';
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background: #1a1a1a;
+	box-shadow: inset 0 0 1px 1px rgba(0, 0, 0, 0.8);
+}
+
+#homeButton {
+	position: absolute;
+	bottom: -25px;
+	left: 50%;
+	transform: translateX(-50%);
+	width: 40px;
+	height: 14px;
+	border: 1px solid #404040;
+	border-radius: 7px;
+	background: #2c2c2c;
+	box-shadow: 
+		0 0 2px rgba(0, 0, 0, 0.5),
+		inset 0 0 2px rgba(255, 255, 255, 0.1);
+	cursor: pointer;
+	transition: all 0.2s ease;
+}
+
+#homeButton:hover {
+	background: #e74c3c;
+	border-color: #e74c3c;
+}
+
+#cadDiv .content {
+	margin: 0;
+	padding: 0;
+	width: 100%;
+	height: 100%;
+	border: none;
+}
+
+#cadFrame {
+	margin: 0;
+	padding: 0;
+	border: none;
+	width: 100%;
+	height: 100%;
+	display: block;
+	overflow: hidden;
+}
+
+/* Hide scrollbars */
+::-webkit-scrollbar {
+    display: none;
+}
+
 #blackbar {
-	background-color: #333;
+	background-color: #1a1a1a;
 	height: 15px;
 	width: 1100px;
 	color: white;
 	font-family: 'Trebuchet MS', 'Lucida Sans Unicode', 'Lucida Grande', 'Lucida Sans', Arial, sans-serif;
-	
 }
 
 #check-api-data {
-	background-color: #e00000;
+	background-color: #e74c3c;
 	font-family: 'Trebuchet MS', 'Lucida Sans Unicode', 'Lucida Grande', 'Lucida Sans', Arial, sans-serif;
 	color: white;
 	width: 100%;
-	height:20px;
-	line-height:20px;
-	font-weight: bolder;
-	text-align:center;
+	height: 20px;
+	line-height: 20px;
+	font-weight: bold;
+	text-align: center;
 }
 
 /* Mini-Cad Hud */
 a {
 	color: white;
 	text-decoration: none; /* no underline */
-	font-size: 18px;
+	font-size: 14px;
+	transition: all 0.2s ease;
+}
+
+a:hover {
+	opacity: 0.8;
 }
 
 .control {
-	font-size: 18px;
+	font-size: 16px;
+	padding: 0 5px;
 }
 
 #hudDiv {
-	font-family: system-ui;
+	font-family: 'Segoe UI', -apple-system, BlinkMacSystemFont, system-ui, Roboto, sans-serif;
 	position: absolute;
 	top: 3%;
 	left: 86%;
 	transform: translate(-50%, 0);
-	width: 300px;
-	height: 130px;
-
-	border: 1px black solid;
-	border-top-width: 1px;
-	border-bottom-width: 1px;
-	border-radius: 1px;
+	width: 360px;
+	height: auto;
+	border-radius: 8px;
+	overflow: hidden;
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+	background: #2c2c2c;
+	border: 1px solid #404040;
 }
+
 #hudFrame {
 	text-align: center;
 }
+
 #hudFrame #hudHeader {
-	height: 15%;
-	background-color: rgb(70, 70, 70);
+	height: 44px;
+	background: #1a1a1a;
 	color: white;
 	display: flex;
-    justify-content: space-between;
+	justify-content: space-between;
 	align-items: center;
-	font-size: 12px;
-	padding: 0 5;
-	border-bottom: 1px solid red;
+	font-size: 13px;
+	padding: 0 16px;
+	border-bottom: 2px solid #e74c3c;
 }
+
+#hudHeaderCalls {
+	font-weight: 600;
+	color: #ffffff;
+	background: #e74c3c;
+	padding: 4px 8px;
+	border-radius: 4px;
+	font-size: 12px;
+}
+
+#hudHeaderTime {
+	font-weight: 500;
+	color: #b0b0b0;
+}
+
+#hudHeaderControls {
+	display: flex;
+	gap: 6px;
+}
+
+#hudHeaderControls .control {
+	width: 22px;
+	height: 22px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: 4px;
+	background: #404040;
+	transition: all 0.2s ease;
+}
+
+#hudHeaderControls .control:hover {
+	background: #e74c3c;
+}
+
 #hudFrame #hudContent {
-	height: 65%;
-	background-color: rgb(70, 70, 70,0.8);
-	font-weight: bold;
+	height: auto;
+	min-height: 110px;
+	background: #2c2c2c;
+	font-weight: 500;
 	color: white;
 	display: flex;
-    justify-content: space-evenly;
-    align-items: center;
+	justify-content: space-evenly;
+	align-items: center;
 	flex-direction: column;
+	padding: 16px;
 }
+
 #hudFrame #hudContent #callCode {
-	font-size: 14px;
+	font-size: 17px;
+	color: #e74c3c;
+	font-weight: 700;
+	margin-bottom: 6px;
+	letter-spacing: 0.3px;
 }
+
 #hudFrame #hudContent #callTitle {
-	font-size: 12px;
+	font-size: 14px;
+	margin-bottom: 6px;
+	color: #ffffff;
+	font-weight: 600;
+	line-height: 1.3;
+	max-width: 100%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	display: block;
 }
+
 #hudFrame #hudContent #callLocation {
-	font-size: 12px;
+	font-size: 13px;
+	margin-bottom: 10px;
+	color: #b0b0b0;
+	background: #404040;
+	padding: 4px 8px;
+	border-radius: 4px;
+	max-width: 100%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	display: block;
 }
+
 #hudFrame #hudContent #callUnits {
 	font-size: 12px;
 	display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: center;
-    align-items: center;
+	flex-direction: row;
+	flex-wrap: wrap;
+	justify-content: center;
+	align-items: center;
+	gap: 4px;
+	padding: 6px 0;
 }
+
 #hudFrame #hudContent #callUnits #nounits {
-	color: tomato;
+	color: #e74c3c;
+	font-style: italic;
+	opacity: 0.9;
+	background: #1a1a1a;
+	padding: 3px 6px;
+	border-radius: 3px;
+	border: 1px solid #404040;
 }
+
 #hudFrame #hudContent #callUnits .unit {
-	background-color: #9c27b0;
-    border-radius: 4px;
-    padding: 0.5px 3px;
+	background: #e74c3c;
+	border-radius: 3px;
+	padding: 3px 6px;
+	font-size: 11px;
+	letter-spacing: 0.3px;
+	font-weight: 600;
+	max-width: 80px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	display: inline-block;
 }
-/* #hudFrame .hudContent #callUnits .unavailable {
-	background-color: rgb(193, 0, 21);
-    border-radius: 4px;
-    padding: 0.5px 3px;
-}
-#hudFrame .hudContent #callUnits .busy {
-	background-color: rgb(255, 111, 0);
-    border-radius: 4px;
-    padding: 0.5px 3px;
-}
-#hudFrame .hudContent #callUnits .available {
-	background-color: rgb(38, 166, 154);
-    border-radius: 4px;
-    padding: 0.5px 3px;
-}
-#hudFrame .hudContent #callUnits .enroute {
-	background-color: rgb(38, 83, 166);;
-    border-radius: 4px;
-    padding: 0.5px 3px;
-}
-#hudFrame .hudContent #callUnits .onscene {
-	background-color: rgb(38, 166, 66);
-    border-radius: 4px;
-    padding: 0.5px 3px;
-} */
 
 #hudFrame #hudFooter {
-	height: 20%;
-	background-color: rgb(70, 70, 70);
+	height: 44px;
+	background: #1a1a1a;
 	color: white;
 	display: flex;
-    justify-content: space-between;
+	justify-content: space-between;
 	align-items: center;
-	padding: 0 5;
+	padding: 0 12px;
+	border-top: 1px solid #404040;
+}
+
+#hudFrame #hudFooter a {
+	padding: 6px 10px;
+	border-radius: 4px;
+	transition: all 0.2s ease;
+	font-weight: 500;
+	font-size: 12px;
+	background: #404040;
+}
+
+#hudFrame #hudFooter a:hover {
+	background: #e74c3c;
 }
 
 #hudFrame #hudFooter .hidden {
-	color: rgb(70, 70, 70);
+	color: rgba(70, 70, 70, 0.3);
+	background: #2c2c2c;
+	border: 1px solid #404040;
+	cursor: not-allowed;
+}
+
+#hudFrame #hudFooter .hidden:hover {
+	background: #2c2c2c;
+}
+
+#hudFrame #hudFooter a.active {
+	background: #e74c3c;
+	color: white;
+}
+
+#hudFrame #hudFooter a.details-active {
+	background: #e74c3c;
+	color: white;
 }
 
 #hudDetails {
-	padding: 10px 10px;
-	background-color: rgb(70, 70, 70,0.8);
+	padding: 12px 16px;
+	background: #262626;
+	font-weight: 500;
+	color: white;
+	display: block;
+	border-top: 1px solid #404040;
+}
+
+#hudDetails .label {
+	padding-bottom: 6px;
+	color: #e74c3c;
+	font-size: 12px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.3px;
+	display: block;
+	margin-top: 8px;
+}
+
+#hudDetails .label:first-child {
+	margin-top: 0;
+}
+
+#hudDetails #callDescription {
+	font-size: 13px;
+	padding: 8px;
+	line-height: 1.4;
+	color: #e0e0e0;
+	background: #2c2c2c;
+	border-radius: 4px;
+	border: 1px solid #404040;
+	margin-bottom: 8px;
+	display: block;
+	word-wrap: break-word;
+	overflow-wrap: break-word;
+	max-width: 100%;
+}
+
+#hudDetails #callNotes {
+	display: block;
+	width: 100%;
+}
+
+#hudDetails #callNotes span {
+	font-size: 12px;
+	padding: 6px 8px;
+	border-bottom: 1px solid #404040;
+	background: #2c2c2c;
+	border-radius: 3px;
+	line-height: 1.3;
+	display: block;
+	margin-bottom: 4px;
+	word-wrap: break-word;
+	overflow-wrap: break-word;
+	max-width: 100%;
+}
+
+#hudDetails #callNotes span:last-child {
+	border-bottom: none;
+	margin-bottom: 0;
+}
+
+#hudInput {
+	height: 48px;
+	background: #1a1a1a;
+	color: white;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 0 12px;
+	border-top: 1px solid #404040;
+	gap: 8px;
+}
+
+#hudInput input {
+	background: #2c2c2c;
+	color: white;
+	border: 1px solid #404040;
+	border-radius: 4px;
+	padding: 6px 10px;
+	transition: all 0.2s ease;
+	font-size: 13px;
+}
+
+#hudInput input:focus {
+	outline: none;
+	border-color: #e74c3c;
+	background: #2c2c2c;
+}
+
+#hudInput #newnote {
+	width: 85%;
+	font-size: 13px;
+}
+
+#hudInput #addnote {
+	width: 15%;
+	background: #e74c3c;
+	cursor: pointer;
 	font-weight: bold;
 	color: white;
-	display: flex;
-    justify-content: space-evenly;
-    align-items: flex-start;
-	flex-direction: column;
+	border: none;
+	border-radius: 4px;
+	transition: all 0.2s ease;
 }
-#hudDetails .label {
-	padding-bottom: 5px;
-}
-#hudDetails #callDescription {
-	font-size: 12px;
-	padding-bottom: 5px;
-}
-#hudDetails #callNotes {
-	display: flex;
-    flex-direction: column;
-}
-#hudDetails #callNotes span {
-	font-size: 11px;
-}
-#hudInput {
-	height: 20%;
-	background-color: rgb(70, 70, 70);
-	color: white;
-	display: flex;
-    justify-content: space-between;
-	align-items: center;
-	padding: 0 5;
-}
-#hudInput input {
-	background-color: rgb(70, 70, 70,0.8);
-	color: white;
-}
-#hudInput #newnote {
-	width: 90%;
-}
-#hudInput #addnote {
-	width: 10%;
+
+#hudInput #addnote:hover {
+	background: #c0392b;
 }

--- a/tablet/html/style.css
+++ b/tablet/html/style.css
@@ -1,4 +1,3 @@
-/* The device with borders */
 /* Tablet Device */
 #cadDiv {
 	position: absolute;
@@ -97,6 +96,19 @@
 	height: 100%;
 	display: block;
 	overflow: hidden;
+	pointer-events: auto;
+}
+
+/* Prevent iframe interference during drag operations */
+.dragging #cadFrame {
+	pointer-events: none;
+}
+
+/* Ensure drag elements maintain pointer events during drag */
+#hudDiv.dragging,
+#cadDiv.dragging {
+	pointer-events: auto;
+	z-index: 9999;
 }
 
 /* Hide scrollbars */
@@ -178,21 +190,11 @@ a:hover {
 	padding: 4px 8px;
 	border-radius: 4px;
 	font-size: 12px;
-	max-width: 60px;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	display: inline-block;
 }
 
 #hudHeaderTime {
 	font-weight: 500;
 	color: #b0b0b0;
-	max-width: 120px;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	display: inline-block;
 }
 
 #hudHeaderControls {
@@ -234,11 +236,6 @@ a:hover {
 	font-weight: 700;
 	margin-bottom: 6px;
 	letter-spacing: 0.3px;
-	max-width: 100%;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	display: block;
 }
 
 #hudFrame #hudContent #callTitle {
@@ -321,11 +318,6 @@ a:hover {
 	font-weight: 500;
 	font-size: 12px;
 	background: #404040;
-	max-width: 60px;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	display: inline-block;
 }
 
 #hudFrame #hudFooter a:hover {
@@ -390,9 +382,6 @@ a:hover {
 	word-wrap: break-word;
 	overflow-wrap: break-word;
 	max-width: 100%;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
 }
 
 #hudDetails #callNotes {
@@ -412,9 +401,6 @@ a:hover {
 	word-wrap: break-word;
 	overflow-wrap: break-word;
 	max-width: 100%;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
 }
 
 #hudDetails #callNotes span:last-child {
@@ -442,8 +428,6 @@ a:hover {
 	padding: 6px 10px;
 	transition: all 0.2s ease;
 	font-size: 13px;
-	overflow: hidden;
-	text-overflow: ellipsis;
 }
 
 #hudInput input:focus {

--- a/tablet/html/style.css
+++ b/tablet/html/style.css
@@ -178,11 +178,21 @@ a:hover {
 	padding: 4px 8px;
 	border-radius: 4px;
 	font-size: 12px;
+	max-width: 60px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	display: inline-block;
 }
 
 #hudHeaderTime {
 	font-weight: 500;
 	color: #b0b0b0;
+	max-width: 120px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	display: inline-block;
 }
 
 #hudHeaderControls {
@@ -224,6 +234,11 @@ a:hover {
 	font-weight: 700;
 	margin-bottom: 6px;
 	letter-spacing: 0.3px;
+	max-width: 100%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	display: block;
 }
 
 #hudFrame #hudContent #callTitle {
@@ -306,6 +321,11 @@ a:hover {
 	font-weight: 500;
 	font-size: 12px;
 	background: #404040;
+	max-width: 60px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	display: inline-block;
 }
 
 #hudFrame #hudFooter a:hover {
@@ -370,6 +390,9 @@ a:hover {
 	word-wrap: break-word;
 	overflow-wrap: break-word;
 	max-width: 100%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 #hudDetails #callNotes {
@@ -389,6 +412,9 @@ a:hover {
 	word-wrap: break-word;
 	overflow-wrap: break-word;
 	max-width: 100%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 #hudDetails #callNotes span:last-child {
@@ -416,6 +442,8 @@ a:hover {
 	padding: 6px 10px;
 	transition: all 0.2s ease;
 	font-size: 13px;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 #hudInput input:focus {

--- a/tablet/html/style.css
+++ b/tablet/html/style.css
@@ -11,7 +11,6 @@
 	border-bottom-width: 35px;
 	border-radius: 35px;
 	background: #2c2c2c;
-	transition: all 0.3s ease;
 	box-shadow: 
 		0 4px 16px rgba(0, 0, 0, 0.2),
 		0 2px 8px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
As described on Discord: https://discord.com/channels/611781170895781888/1392992430466404402/1392992430466404402
### Features

* Added config option to **auto-hide the mini-CAD** when a player exits a vehicle and automatically restore it when they re-enter
* Added new config options to **restrict CAD access** unless one of the following conditions is met:

  * **QB & ESX**: Player possesses a specific item (e.g., a tablet) in their inventory
  * **QB & ESX**: Character belongs to the appropriate job/faction—units will only display if relevant
  * **QB & ESX**: Character holds a permitted job (CAD access based on job)
  * Player is inside a **whitelisted emergency vehicle**

### Testing

* Light testing performed; new config options are working as expected
* No UI-specific issues observed—any attach/detach or refresh-related delays appear to stem from backend behavior