### PR TITLE
Adds aliases for v1 API endpoints

### DIFF
--- a/sonorancad/core/sonoran_api.lua
+++ b/sonorancad/core/sonoran_api.lua
@@ -1042,3 +1042,8 @@ legacyApiHandlers = {
         return CadApiCheckCommunityLink(get_legacy_request_payload(data))
     end
 }
+
+-- Alias for v1 API endpoints
+legacyApiHandlers.UNIT_PANIC = legacyApiHandlers.PANIC
+legacyApiHandlers.CALL_911 = legacyApiHandlers.CREATE_911_CALL
+legacyApiHandlers.LOOKUP_VALUE = legacyApiHandlers.LOOKUP_BY_VALUE


### PR DESCRIPTION
## Description

Adds back three v1 endpoints as aliases for their new v2 counterparts.
Without these aliases, existing third-party resources using `performApiRequest` will silently fail because the endpoints have been renamed in v2.

## Motivation and Context

🕺 

## How Has This Been Tested?

Locally with Fire Alarm Reborn.

## Contributor License Agreement

By submitting this pull request, you certify that you have read and agree to the project’s Contributor License Agreement (CLA) under the PolyForm Noncommercial 1.0.0 license.

> I, @cm8263, hereby agree to license my contributions to SonoranCADFiveM under the PolyForm Noncommercial License 1.0.0.

## Checklist

* [x] My code follows the project’s coding style and conventions
* [x] I have updated documentation where necessary
* [x] I have read, signed, and agreed to the Contributor License Agreement (CLA)
