### PR TITLE
Add protected API key convar accessible by trusted resources

### DIFF
--- a/sonorancad/core/configuration.lua
+++ b/sonorancad/core/configuration.lua
@@ -358,7 +358,14 @@ for k, v in pairs(json.decode(conf)) do
     local cvar = GetConvar('sonoran_' .. k, 'NONE')
     local cvar_setter = GetConvar('sonoran_' .. k .. '_setter', 'NONE')
     local val = nil
-    if cvar ~= 'NONE' and cvar ~= 'statusLabels' then
+    if k == 'apiKey' then
+        if cvar == 'NONE' then
+            warnLog(('Configuration: apiKey convar value NOT initialized - has sonorancad.cfg been executed?'))
+        elseif cvar == 'protection_initialized' then
+            SetConvar('sonoran_' .. k, tostring(v))
+        end
+    end
+    if cvar ~= 'NONE' and cvar ~= 'statusLabels' and k ~= 'apiKey' then
         if cvar_setter == 'NONE' or cvar_setter == 'server' then
             infoLog(
                 ('Configuration: Overriding config option %s with convar. New value: %s'):format(

--- a/sonorancad/sonorancad.cfg
+++ b/sonorancad/sonorancad.cfg
@@ -1,3 +1,9 @@
+# Convar Protections
+set sonoran_apiKey "protection_initialized"
+add_convar_permission sonorancad read sonoran_apiKey
+add_convar_permission inferno-pager-reborn read sonoran_apiKey
+add_convar_permission inferno-station-alert read sonoran_apiKey
+
 # Start the sonorancad resource and other bundled resources
 add_unsafe_child_process_permission sonorancad
 ensure pNotify


### PR DESCRIPTION
## Description

Adds the community API key as a protected server-only convar, accessible only via a hard-coded list of resources.
When `sonorancad.cfg` has not been executed (i.e., the protections have not be enabled), the value won't be written to the convar.

## Motivation and Context

Allows trusted third-party resources to access the API key for use with Sonoran libs (such as Sonoran.Net).

## How Has This Been Tested?

Test with Pager Reborn

## Contributor License Agreement

By submitting this pull request, you certify that you have read and agree to the project’s Contributor License Agreement (CLA) under the PolyForm Noncommercial 1.0.0 license.

> I, @cm8263, hereby agree to license my contributions to SonoranCADFiveM under the PolyForm Noncommercial License 1.0.0.

## Checklist

* [x] My code follows the project’s coding style and conventions
* [x] I have updated documentation where necessary
* [x] I have read, signed, and agreed to the Contributor License Agreement (CLA)
