### PR TITLE
Adds callback support to GetUnitCache

### DIFF
--- a/sonorancad/core/shared_functions.lua
+++ b/sonorancad/core/shared_functions.lua
@@ -298,3 +298,10 @@ if IsDuplicityVersion() then
         TriggerClientEvent("SonoranCAD::core:Notify", target, buildNotificationPayload(input))
     end
 end
+
+function isCallbackValid(value)
+    if type(value) == "function" then return true end
+    if type(value) == "table" and rawget(value, "__cfx_functionReference") then return true end
+
+    return false
+end

--- a/sonorancad/core/sonoran_api.lua
+++ b/sonorancad/core/sonoran_api.lua
@@ -448,13 +448,6 @@ local function invoke_legacy_handler(request_type, data)
     return response
 end
 
-local function isCallbackValid(value)
-    if type(value) == "function" then return true end
-    if type(value) == "table" and rawget(value, "__cfx_functionReference") then return true end
-
-    return false
-end
-
 function performApiRequest(data, request_type, callback)
     local response = invoke_legacy_handler(request_type, data)
 

--- a/sonorancad/core/unittracking.lua
+++ b/sonorancad/core/unittracking.lua
@@ -124,10 +124,16 @@ function GetSourceByCadIdentity(identities)
     return nil
 end
 
-function GetUnitCache(includeDispatchers)
+function GetUnitCache(includeDispatchers, callback)
     if includeDispatchers then
+
+        if isCallbackValid(callback) then callback(UnitCache, ActiveDispatchers) end
+
         return UnitCache, ActiveDispatchers
     end
+
+    if isCallbackValid(callback) then callback(UnitCache, {}) end
+
     return UnitCache
 end
 function GetCallCache() return CallCache end


### PR DESCRIPTION
## Description

Adds callback support for `GetUnitCache`

## Motivation and Context

👯 

## How Has This Been Tested?

Locally with Pager Reborn (with and without callback)

## Contributor License Agreement

By submitting this pull request, you certify that you have read and agree to the project’s Contributor License Agreement (CLA) under the PolyForm Noncommercial 1.0.0 license.

> I, @cm8263, hereby agree to license my contributions to SonoranCADFiveM under the PolyForm Noncommercial License 1.0.0

## Checklist

* [x] My code follows the project’s coding style and conventions
* [x] I have updated documentation where necessary
* [x] I have read, signed, and agreed to the Contributor License Agreement (CLA)
