### PR TITLE
[codex] Add record unique conflict API error

### DIFF
--- a/errors.md
+++ b/errors.md
@@ -177,6 +177,11 @@ Warnings use a `WRN-*` prefix. Errors use an `ERR-*` prefix. Some warning-level 
 - `Meaning`: The local server connection to SonoranCAD timed out.
 - `Potential Fix`: If you are seeing this routinely, contact your server host. Check the server host, firewall, proxy, or upstream network connection for connection setup delays or blocked outbound traffic.
 
+### ERR-CORE-035
+- `Key`: `CAD_RECORD_UNIQUE_CONFLICT`
+- `Meaning`: A CAD record create or edit request failed because one of the fields marked unique already has the same value on another record.
+- `Potential Fix`: Find the unique field value in the record payload, choose a value that is not already used, or update the existing CAD record instead of creating a duplicate.
+
 ### ERR-CORE-900
 - `Key`: `UNHANDLED_SERVER_ERROR`
 - `Meaning`: An unexpected server-side error occurred and was normalized into a generic coded failure.

--- a/sonorancad/core/logging.lua
+++ b/sonorancad/core/logging.lua
@@ -69,6 +69,7 @@ local ErrorCodes = {
     ['CAD_API_REQUEST_FAILED'] = { code = "ERR-CORE-029", message = "A CAD API request failed." },
     ['LOCAL_NETWORK_TIMEOUT'] = { code = "ERR-CORE-033", message = "The local server network timed out while connecting to SonoranCAD. Check the server host, firewall, proxy, or upstream network connection." },
     ['LOCAL_NETWORK_CONNECT_TIMEOUT'] = { code = "ERR-CORE-034", message = "The local server connection to SonoranCAD timed out. Check the server host, firewall, proxy, or upstream network connection." },
+    ['CAD_RECORD_UNIQUE_CONFLICT'] = { code = "ERR-CORE-035", message = "The CAD record could not be saved because a unique field value is already used by another record." },
     ['SMARTSIGNS_PLAN_REQUIRED'] = { code = "ERR-SS-101", message = "Smart Signs authentication failed because the CAD community does not have access to the required Smart Signs feature or plan." },
     ['SMARTSIGNS_AUTH_FAILED'] = { code = "ERR-SS-102", message = "Smart Signs authentication failed. Check the SonoranCAD API key, community ID, and server ID configured for this resource." },
     ['SMARTSIGNS_HELPER_STARTED'] = { code = "ERR-SS-103", message = "The smartsigns_sonoran_helper resource is for Smart Signs internal update handling and should not be started directly." },

--- a/sonorancad/core/sonoran_api.lua
+++ b/sonorancad/core/sonoran_api.lua
@@ -236,6 +236,19 @@ local function cad_api_reason_contains(response, text)
     return CadApiReasonText(reason):lower():find(text:lower(), 1, true) ~= nil
 end
 
+local function get_response_status(response)
+    if type(response) ~= "table" then
+        return nil
+    end
+    if response.status ~= nil then
+        return tonumber(response.status)
+    end
+    if type(response.reason) == "table" and response.reason.status ~= nil then
+        return tonumber(response.reason.status)
+    end
+    return nil
+end
+
 local function get_local_network_error(response)
     local reason = response and response.reason
     if type(reason) ~= "table" then
@@ -305,8 +318,18 @@ local function get_streetsigns_auth_error(response)
 end
 
 local function get_request_specific_error(request_name, response)
-    if tostring(request_name or ""):upper() == "AUTH_STREETSIGNS" then
+    local normalized_request_name = tostring(request_name or ""):upper()
+    if normalized_request_name == "AUTH_STREETSIGNS" then
         return get_streetsigns_auth_error(response)
+    end
+
+    if (normalized_request_name == "CREATE_RECORD" or
+        normalized_request_name == "EDIT_RECORD" or
+        normalized_request_name == "UPDATE_RECORD") and get_response_status(response) == 409 then
+        return {
+            key = "CAD_RECORD_UNIQUE_CONFLICT",
+            message = "A CAD record create or edit request was rejected because a unique field value is already used by another record."
+        }
     end
 
     return nil
@@ -366,6 +389,11 @@ function CadApiLogFailure(request_name, response, payload)
 
         if requestSpecificError.key == "SMARTSIGNS_AUTH_FAILED" then
             logError("SMARTSIGNS_AUTH_FAILED", detail)
+            return
+        end
+
+        if requestSpecificError.key == "CAD_RECORD_UNIQUE_CONFLICT" then
+            logError("CAD_RECORD_UNIQUE_CONFLICT", detail)
             return
         end
 

--- a/sonorancad/lua/sonoran/client.lua
+++ b/sonorancad/lua/sonoran/client.lua
@@ -740,20 +740,23 @@ function Client:_request(method, path, options)
       else
         return {
           success = false,
-          reason = parsed ~= nil and parsed or "Request was rate limited."
+          reason = parsed ~= nil and parsed or "Request was rate limited.",
+          status = tonumber(response and response.status) or 429
         }
       end
     elseif tonumber(response and response.status) == 429 then
       self:_error_log_http_failure(request_options, response, parsed, attempt, "HTTP 429 rate limit received. Automatic retries have been exhausted.")
       return {
         success = false,
-        reason = parsed ~= nil and parsed or "Request was rate limited."
+        reason = parsed ~= nil and parsed or "Request was rate limited.",
+        status = tonumber(response and response.status) or 429
       }
     else
       self:_error_log_http_failure(request_options, response, parsed, attempt, "HTTP request failed.")
       return {
         success = false,
-        reason = parsed
+        reason = parsed,
+        status = tonumber(response and response.status) or 0
       }
     end
 
@@ -761,7 +764,8 @@ function Client:_request(method, path, options)
 
   return {
     success = false,
-    reason = "Request was rate limited."
+    reason = "Request was rate limited.",
+    status = 429
   }
 end
 


### PR DESCRIPTION
## Summary
- Add `ERR-CORE-035` / `CAD_RECORD_UNIQUE_CONFLICT` for CAD record create/edit HTTP 409 conflicts.
- Preserve HTTP status on failed Sonoran.lua responses so wrapper error mapping can detect 409 responses.
- Document the new code in the resource `errors.md` registry.

## Root cause
Record create/edit failures returned the generic CAD API request failure because failed SDK responses did not expose the HTTP status to the core wrapper.

## Validation
- `python .codex/skills/logging-error-code-audit/scripts/audit_log_codes.py .`

## Docs
- Pushed matching GitBook docs update to `SonoranCAD-Documentation/master` in commit `fa307ca`.