### PR TITLE
[codex] Fix livemap vehicle model config loading

### DIFF
--- a/sonorancad/configuration/livemap_vehicle_models.json
+++ b/sonorancad/configuration/livemap_vehicle_models.json
@@ -70,12 +70,5 @@
     "sizeOffset": 1.0,
     "headingOffset": 0,
     "lights": false
-  },
-  "boat": {
-    "model": "https://s3.sonorancad.com/default/models/boat.glb",
-    "zOffset": 9,
-    "sizeOffset": 0,
-    "headingOffset": 0,
-    "lights": false
   }
 }

--- a/sonorancad/fxmanifest.lua
+++ b/sonorancad/fxmanifest.lua
@@ -49,6 +49,7 @@ files {
     'core/client_nui/js/*.js',
     'core/client_nui/sounds/*.mp3',
     'core/client_nui/img/*.*',
+    'configuration/livemap_vehicle_models.json',
     'submodules/**/*.mp3',
     'submodules/caddisplay/html/**/*',
     'submodules/postals/*.json',

--- a/sonorancad/submodules/locations/sv_locations.lua
+++ b/sonorancad/submodules/locations/sv_locations.lua
@@ -18,7 +18,7 @@ CreateThread(function() Config.LoadPlugin("locations", function(pluginConfig)
         local CoordinateThreshold = 2.0
         local HeadingThreshold = 10.0
         local vehicleModelConfig = {}
-        local vehicleModelConfigPath = "/configuration/livemap_vehicle_models.json"
+        local vehicleModelConfigPath = "configuration/livemap_vehicle_models.json"
 
         local function loadVehicleModelConfig()
             local raw = LoadResourceFile(GetCurrentResourceName(), vehicleModelConfigPath)


### PR DESCRIPTION
## Summary

Fixes `WRN-CORE-900` when the locations submodule tries to load the livemap vehicle model configuration.

## Root cause

The server loader used `/configuration/livemap_vehicle_models.json`, while other resource reads use relative paths such as `configuration/config.json`. That leading slash can cause `LoadResourceFile` to return nil even though the JSON exists in the resource. The model JSON also had a duplicate `boat` key.

## Changes

- Load `configuration/livemap_vehicle_models.json` with a relative path.
- Add the specific model config JSON to the resource manifest instead of using a broad `configuration/*.json` glob.
- Remove the duplicate `boat` entry from the model config.

## Validation

- Ran `git diff --check`.
- Parsed `sonorancad/configuration/livemap_vehicle_models.json` with PowerShell `ConvertFrom-Json`.

Not run in a FiveM server runtime.