### PR TITLE
[codex] Fix wraith notification resource warning

### DIFF
--- a/sonorancad/core/configuration.lua
+++ b/sonorancad/core/configuration.lua
@@ -704,9 +704,18 @@ CreateThread(function()
             warnLog("UNHANDLED_WARNING", ('Warning: wk_wars2x resource in bad start (%s). Ensure it is started to use the wraithv2 resource.'):format(
                     GetResourceState('wk_wars2x')))
         end
-        if GetResourceState('pNotify') ~= 'started' then
-            warnLog("UNHANDLED_WARNING", ('Warning: pNotify is required to see notifications from the wraithv2 plugin but the resource in bad start (%s). Ensure it is started'):format(
-                    GetResourceState('pNotify')))
+        local wraithConfig = Config.GetPluginConfig('wraithv2') or {}
+        local notification = ApplyPluginNotificationOverrides(wraithConfig, {})
+        local notificationSystem = ResolveNotificationSystem(notification.system)
+        local notificationResources = {
+            ox_lib = 'ox_lib',
+            lation_ui = 'lation_ui',
+            pnotify = 'pNotify'
+        }
+        local notificationResource = notificationResources[notificationSystem]
+        if notificationResource ~= nil and GetResourceState(notificationResource) ~= 'started' then
+            warnLog("UNHANDLED_WARNING", ('Warning: %s is configured for wraithv2 notifications but the resource is in bad start (%s). Ensure it is started or set notificationSystem/notificationOverride to auto/chat.'):format(
+                    notificationResource, GetResourceState(notificationResource)))
         end
     end
     if isPluginLoaded('smartsigns') then


### PR DESCRIPTION
## Summary

Updates the wraithv2 startup notification dependency warning to resolve the same effective notification system used by the actual notification send path.

## Details

The wraithv2 ALPR notifications already route through `NotifyPlayer`, `ApplyPluginNotificationOverrides`, and `ResolveNotificationSystem`, so they can use `ox_lib`, `lation_ui`, `pNotify`, or chat depending on global/plugin configuration and auto-detection. The startup check was still hardcoded to warn when `pNotify` was not started, which produced misleading warnings for servers using `ox_lib` or another supported notification backend.

This change checks the resolved notification system and warns only when the selected resource-backed notification system is not started. Chat fallback does not produce a missing-resource warning.

## Validation

- Inspected the existing wraithv2 notification path and shared notification resolver.
- Verified the local diff is scoped to `sonorancad/core/configuration.lua`.
- Lua CLI is not installed in this shell, so a local Lua syntax check could not be run.