### PR TITLE
fix(bodycam): enforce duty on auto-enable

### DIFF
--- a/sonorancad/submodules/bodycam/cl_bodycam.lua
+++ b/sonorancad/submodules/bodycam/cl_bodycam.lua
@@ -376,7 +376,14 @@ CreateThread(function()
                         end
                         return
                     end
-                    if sourceType == 'manual' and (not bodyCamOn or not bodyCamDisplayOn or not peerStreamReady) then
+                    local manualStartPending = sourceType == 'manual' and
+                        (not bodyCamOn or not bodyCamDisplayOn or not peerStreamReady)
+                    local autoStartPending = sourceType == 'auto' and bodyCamOn and bodyCamDisplayOn and
+                        not peerStreamReady
+                    if manualStartPending or autoStartPending then
+                        if pendingRecordingStart then
+                            return
+                        end
                         pendingRecordingStart = {
                             action = action,
                             sourceType = sourceType,
@@ -384,12 +391,14 @@ CreateThread(function()
                             reason = reason,
                             requestedAt = nowMs()
                         }
-                        if not bodyCamDisplayOn then
-                            TriggerServerEvent('SonoranCAD::bodycam::RequestToggle', true, true)
-                        else
-                            StartPeerStream()
+                        if manualStartPending then
+                            if not bodyCamDisplayOn then
+                                TriggerServerEvent('SonoranCAD::bodycam::RequestToggle', true, true)
+                            else
+                                StartPeerStream()
+                            end
                         end
-                        SchedulePendingRecordingStartRetry('manual_start_pending', 12)
+                        SchedulePendingRecordingStartRetry(sourceType .. '_start_pending', 12)
                         return
                     end
                     if not bodyCamOn then

--- a/sonorancad/submodules/bodycam/cl_bodycam.lua
+++ b/sonorancad/submodules/bodycam/cl_bodycam.lua
@@ -2,8 +2,14 @@ bodyCamOn = false
 local bodyCamDisplayOn = false
 local manualDisplayOn = false
 local autoDisplayOn = false
+local autoDisplayRequestPending = false
+local autoDisplayRequestGeneration = 0
+local weaponAutoTriggerLatched = false
+local lightsAutoTriggerLatched = false
+local pendingAutoRecordingTrigger = nil
 local watchingDisplayOn = false
 local forceDisplayOff = false
+local bodycamDutyRevoked = false
 local showOverlay = true
 local doAnimation = true
 local soundLevel = 0.2
@@ -263,7 +269,7 @@ CreateThread(function()
             end
 
             local function shouldDisplayBodycam()
-                if forceDisplayOff then
+                if forceDisplayOff or bodycamDutyRevoked then
                     return false
                 end
                 return manualDisplayOn or autoDisplayOn or watchingDisplayOn
@@ -291,6 +297,29 @@ CreateThread(function()
                     })
                 end
                 PublishBodycamRuntime("display_state")
+            end
+
+            local function cancelAutomaticDisplayRequest()
+                autoDisplayRequestPending = false
+                pendingAutoRecordingTrigger = nil
+            end
+
+            local function requestAutomaticDisplay(recordingTrigger)
+                if forceDisplayOff or autoDisplayOn or autoDisplayRequestPending then
+                    return false
+                end
+
+                autoDisplayRequestGeneration = autoDisplayRequestGeneration + 1
+                local requestGeneration = autoDisplayRequestGeneration
+                autoDisplayRequestPending = true
+                pendingAutoRecordingTrigger = recordingTrigger
+                TriggerServerEvent('SonoranCAD::bodycam::RequestToggle', false, true)
+                SetTimeout(2000, function()
+                    if autoDisplayRequestPending and autoDisplayRequestGeneration == requestGeneration then
+                        cancelAutomaticDisplayRequest()
+                    end
+                end)
+                return true
             end
 
             local function getRecordingMetadata()
@@ -814,16 +843,22 @@ CreateThread(function()
                     Wait(200)
                     local ped = PlayerPedId()
                     local weapon = GetSelectedPedWeapon(ped)
-                    if not autoDisplayOn and pluginConfig.weapons then
+                    local configuredWeapon = false
+                    if type(pluginConfig.weapons) == 'table' then
                         for _, weaponName in ipairs(pluginConfig.weapons) do
-                            if weapon == GetHashKey(weaponName) then
-                                if not forceDisplayOff then
-                                    TriggerServerEvent('SonoranCAD::bodycam::RequestToggle', false, true)
-                                end
-                                triggerAutoRecording('weapon_draw')
+                            local configuredWeaponHash = type(weaponName) == 'number' and weaponName or
+                                GetHashKey(tostring(weaponName))
+                            if weapon == configuredWeaponHash then
+                                configuredWeapon = true
                                 break
                             end
                         end
+                    end
+                    if not configuredWeapon then
+                        weaponAutoTriggerLatched = false
+                    elseif not weaponAutoTriggerLatched then
+                        weaponAutoTriggerLatched = true
+                        requestAutomaticDisplay('weapon_draw')
                     end
                 end
             end)
@@ -836,12 +871,15 @@ CreateThread(function()
                     -- Only check if player is in a vehicle and is the driver
                     if veh ~= 0 and GetPedInVehicleSeat(veh, -1) == ped and GetVehicleClass(veh) == 18 then
                         if IsVehicleSirenOn(veh) then
-                            if not autoDisplayOn then
-                                if not forceDisplayOff then
-                                    TriggerServerEvent('SonoranCAD::bodycam::RequestToggle', false, true)
-                                end
+                            if not lightsAutoTriggerLatched then
+                                lightsAutoTriggerLatched = true
+                                requestAutomaticDisplay()
                             end
+                        else
+                            lightsAutoTriggerLatched = false
                         end
+                    else
+                        lightsAutoTriggerLatched = false
                     end
                 end
             end)
@@ -938,30 +976,48 @@ CreateThread(function()
             end)
 
             RegisterNetEvent('SonoranCAD::bodycam::Toggle', function(manualActivation, toggle, forceOff)
+                local isManualActivation = manualActivation == true
+                local shouldToggle = toggle == true
+                local isForceOff = forceOff == true
+                local automaticRecordingTrigger = nil
+
+                if isManualActivation then
+                    cancelAutomaticDisplayRequest()
+                elseif shouldToggle then
+                    automaticRecordingTrigger = pendingAutoRecordingTrigger
+                    cancelAutomaticDisplayRequest()
+                else
+                    cancelAutomaticDisplayRequest()
+                end
+
                 debugLog(('Bodycam toggle received: manual=%s toggle=%s forceOff=%s initialized=%s'):format(
                     tostring(manualActivation), tostring(toggle), tostring(forceOff), tostring(bodycamInitialized)))
-                if forceDisplayOff and not manualActivation then
+                if forceDisplayOff and not isManualActivation then
                     return
                 end
                 if not IsWearingBodycam() then
-                    if manualActivation then
+                    if isManualActivation then
                         showClientError('BODYCAM_NOT_WORN')
                         return
                     end
                 end
 
-                if manualActivation and not toggle and watchingDisplayOn and not forceOff then
+                if shouldToggle then
+                    bodycamDutyRevoked = false
+                end
+
+                if isManualActivation and not shouldToggle and watchingDisplayOn and not isForceOff then
                     showClientError('BODYCAM_WATCH_ACTIVE')
                     return
                 end
 
-                if forceOff then
+                if isForceOff then
                     forceDisplayOff = true
-                elseif manualActivation and toggle then
+                elseif isManualActivation and shouldToggle then
                     forceDisplayOff = false
                 end
 
-                if manualActivation and doAnimation then
+                if isManualActivation and doAnimation then
                     local ped = PlayerPedId()
                     RequestAnimDict("clothingtie")
                     while not HasAnimDictLoaded("clothingtie") do
@@ -973,15 +1029,15 @@ CreateThread(function()
 
                 local wasDisplayOn = bodyCamDisplayOn
 
-                if manualActivation then
-                    if toggle then
+                if isManualActivation then
+                    if shouldToggle then
                         manualDisplayOn = true
                     else
                         manualDisplayOn = false
                         autoDisplayOn = false
                     end
                 else
-                    if toggle then
+                    if shouldToggle then
                         autoDisplayOn = true
                     else
                         autoDisplayOn = false
@@ -989,9 +1045,9 @@ CreateThread(function()
                 end
 
                 applyDisplayState()
-                if toggle and not forceDisplayOff then
+                if shouldToggle and not forceDisplayOff then
                     StartPeerStream()
-                elseif forceOff then
+                elseif isForceOff then
                     StopPeerStream()
                 end
 
@@ -1008,6 +1064,20 @@ CreateThread(function()
                         end
                     end
                 end
+
+                if automaticRecordingTrigger then
+                    triggerAutoRecording(automaticRecordingTrigger)
+                end
+            end)
+
+            RegisterNetEvent('SonoranCAD::bodycam::DutyRevoked', function()
+                cancelAutomaticDisplayRequest()
+                bodycamDutyRevoked = true
+                manualDisplayOn = false
+                autoDisplayOn = false
+                watchingDisplayOn = false
+                StopPeerStream()
+                applyDisplayState()
             end)
 
             RegisterNetEvent('SonoranCAD::bodycam::RecordingStartRejected', function(code, details)

--- a/sonorancad/submodules/bodycam/cl_bodycam.lua
+++ b/sonorancad/submodules/bodycam/cl_bodycam.lua
@@ -305,7 +305,11 @@ CreateThread(function()
             end
 
             local function requestAutomaticDisplay(recordingTrigger)
-                if forceDisplayOff or autoDisplayOn or autoDisplayRequestPending then
+                if autoDisplayRequestPending then
+                    pendingAutoRecordingTrigger = pendingAutoRecordingTrigger or recordingTrigger
+                    return recordingTrigger ~= nil
+                end
+                if forceDisplayOff or autoDisplayOn then
                     return false
                 end
 

--- a/sonorancad/submodules/bodycam/sv_bodycam.lua
+++ b/sonorancad/submodules/bodycam/sv_bodycam.lua
@@ -590,6 +590,14 @@ CreateThread(function()
                 TriggerClientEvent('SonoranCAD::bodycam::GiveSound', -1, source, GetEntityCoords(GetPlayerPed(source)))
             end)
 
+            local function resetAutomaticDisplay(target)
+                TriggerClientEvent('SonoranCAD::bodycam::Toggle', target, false, false)
+            end
+
+            local function revokeBodycamDisplay(target)
+                TriggerClientEvent('SonoranCAD::bodycam::DutyRevoked', target)
+            end
+
             AddEventHandler('SonoranCAD::pushevents:UnitPanic', function(unit, identId, isPanic)
                 if not isPanic or not unit then
                     return
@@ -602,17 +610,19 @@ CreateThread(function()
 
             RegisterNetEvent('SonoranCAD::bodycam::RequestToggle', function(manualActivation, toggle)
                 local src = source
+                local isManualActivation = manualActivation == true
+                local wantsEnable = toggle == true
                 local unit = GetUnitByPlayerId(src)
                 debugLog(('Bodycam toggle requested: src=%s manual=%s toggle=%s unitFound=%s'):format(
-                    tostring(src), tostring(manualActivation), tostring(toggle), tostring(unit ~= nil)))
+                    tostring(src), tostring(isManualActivation), tostring(wantsEnable), tostring(unit ~= nil)))
 
-                if not toggle then
-                    TriggerClientEvent('SonoranCAD::bodycam::Toggle', src, manualActivation, false)
+                if not wantsEnable then
+                    TriggerClientEvent('SonoranCAD::bodycam::Toggle', src, isManualActivation, false)
                     return
                 end
 
                 if pluginConfig.requireUnitDuty and unit == nil then
-                    if manualActivation then
+                    if isManualActivation then
                         local cadState = isPlayerInCAD(src)
                         local rejectionCode = cadState.linked and 'BODYCAM_NOT_ON_DUTY' or 'PLAYER_NOT_IN_CAD'
                         local rejectionDetails = ('Bodycam enable rejected: src=%s linked=%s online=%s unitFound=false requireUnitDuty=true'):format(
@@ -627,10 +637,11 @@ CreateThread(function()
                         TriggerClientEvent('SonoranCAD::bodycam::RecordingStartRejected', src, rejectionCode,
                             rejectionDetails)
                     end
+                    resetAutomaticDisplay(src)
                     return
                 end
 
-                TriggerClientEvent('SonoranCAD::bodycam::Toggle', src, manualActivation, toggle)
+                TriggerClientEvent('SonoranCAD::bodycam::Toggle', src, isManualActivation, true)
             end)
 
             RegisterNetEvent('SonoranCAD::bodycam::PublishRuntime', function(payload)
@@ -639,7 +650,10 @@ CreateThread(function()
 
                 local unit = GetUnitByPlayerId(src)
                 local active = payload.active == true
-                if pluginConfig.requireUnitDuty and unit == nil then active = false end
+                if pluginConfig.requireUnitDuty and unit == nil and active then
+                    active = false
+                    revokeBodycamDisplay(src)
+                end
                 local peerId = type(payload.peerId) == "string" and
                     payload.peerId:sub(1, 128) or nil
                 if peerId and (peerId == "" or peerId:find("[^%w_%-%.]")) then
@@ -685,6 +699,11 @@ CreateThread(function()
                             emitRuntime("BODYCAM_REMOVED", feed)
                         elseif pluginConfig.requireUnitDuty and
                             GetUnitByPlayerId(feed.playerSource) == nil then
+                            if feed.active == true then
+                                revokeBodycamDisplay(feed.playerSource)
+                            else
+                                resetAutomaticDisplay(feed.playerSource)
+                            end
                             BodycamRuntime.feeds[key] = nil
                             emitRuntime("BODYCAM_REMOVED", feed)
                         end


### PR DESCRIPTION
## Description

Hardens bodycam weapon and siren auto-enable so CAD duty authorization remains server-authoritative.

- Edge-latches weapon and siren triggers to prevent repeated denied requests.
- Starts weapon-triggered recording only after the server accepts the toggle.
- Resets denied automatic state and fully revokes active display/stream state when duty is lost.
- Preserves manual disable, staff force-off, and `requireUnitDuty = false` behavior.

## Motivation and Context

A user reported bodycam activation after drawing a weapon despite being new and not on duty in CAD. Current master already rejects a direct no-unit enable, so that exact bypass was not reproduced. The investigation did identify repeated rejected requests, pre-authorization recording attempts, and stale client state after duty loss; this PR closes those concrete gaps.

Weapons are matched against the local `bodycam_config.weapons` list, not a CAD weapon registry.

## How Has This Been Tested?

- `git diff --check`
- `npx --yes luaparse@0.3.1 sonorancad/submodules/bodycam/cl_bodycam.lua`
- `npx --yes luaparse@0.3.1 sonorancad/submodules/bodycam/sv_bodycam.lua`
- Static scenario review for unlinked, off-duty, on-duty, unconfigured-weapon, `requireUnitDuty = false`, siren, manual-disable, and force-off paths

Live FXServer/FiveM runtime validation has not been performed.

## Contributor License Agreement

> I, **Jordan2139**, hereby agree to license my contributions to SonoranCADFiveM under the PolyForm Noncommercial License 1.0.0.

## Checklist

- [x] My code follows the project's coding style and conventions
- [x] I have updated documentation where necessary
- [x] I have read, signed, and agreed to the Contributor License Agreement (CLA)