### PR TITLE
fix(ers): check night_ers compatibility

### DIFF
--- a/errors.md
+++ b/errors.md
@@ -573,6 +573,11 @@ Warnings use a `WRN-*` prefix. Errors use an `ERR-*` prefix. Some warning-level 
 - `Meaning`: The Night ERS resource required by the integration is not started.
 - `Potential Fix`: Start the ERS resource before enabling the ERS integration submodule.
 
+### ERR-ERS-106
+- `Key`: `ERS_VERSION_TOO_OLD`
+- `Meaning`: The installed `night_ers` resource is below the minimum supported version `1.8.16`, or its version metadata could not be verified; the ERS integration may not work.
+- `Potential Fix`: Confirm `night_ers` reports version `1.8.16` or newer in its resource metadata, update the resource if needed, and restart it before troubleshooting the integration.
+
 ## Framework Errors
 
 ### ERR-FW-101

--- a/sonorancad/core/logging.lua
+++ b/sonorancad/core/logging.lua
@@ -131,6 +131,7 @@ local ErrorCodes = {
     ['ERS_COORDS_MISSING'] = { code = "ERR-ERS-103", message = "An ERS event was missing valid coordinates." },
     ['ERS_CALL_ID_INVALID'] = { code = "ERR-ERS-104", message = "ERS attempted to use an invalid saved call ID." },
     ['ERS_RESOURCE_NOT_STARTED'] = { code = "ERR-ERS-105", message = "The required Night ERS resource is not started." },
+    ['ERS_VERSION_TOO_OLD'] = { code = "ERR-ERS-106", message = "The night_ers version is below the minimum supported version or could not be verified; the ERS integration may not work." },
     ['FRAMEWORK_RESOURCE_MISSING'] = { code = "ERR-FW-101", message = "A required framework resource is not started." },
     ['FRAMEWORK_IDENTITY_MISSING'] = { code = "ERR-FW-102", message = "Framework identity data could not be retrieved for the player." },
     ['LOCATIONS_CONFIG_MISSING'] = { code = "ERR-LOC-101", message = "The locations/livemap configuration file is missing." },

--- a/sonorancad/submodules/ersintegration/sv_ersintegration.lua
+++ b/sonorancad/submodules/ersintegration/sv_ersintegration.lua
@@ -9,7 +9,59 @@ local pluginConfig = Config.GetPluginConfig("ersintegration") or {}
 local postalConfig = Config.GetPluginConfig("postals") or {}
 
 if pluginConfig.enabled then
+    local ERS_MINIMUM_VERSION = "1.8.16"
+
+    local function checkErsVersion()
+        local metadataOk, currentVersion = pcall(GetResourceMetadata, "night_ers", "version", 0)
+        local normalizedVersion
+
+        if metadataOk and type(currentVersion) == "string" then
+            local major, minor, patch = currentVersion:match("^%s*(%d+)%.(%d+)%.(%d+)%s*$")
+            if major ~= nil then
+                normalizedVersion = ("%s.%s.%s"):format(major, minor, patch)
+            end
+        end
+
+        if normalizedVersion == nil then
+            local detectedVersion
+            if not metadataOk then
+                detectedVersion = "metadata lookup failed: " .. tostring(currentVersion)
+            elseif currentVersion == nil then
+                detectedVersion = "unavailable"
+            elseif type(currentVersion) ~= "string" then
+                detectedVersion = "malformed (" .. type(currentVersion) .. ")"
+            elseif currentVersion == "" then
+                detectedVersion = "empty"
+            else
+                detectedVersion = currentVersion
+            end
+
+            errorLog("ERS_VERSION_TOO_OLD", ("The night_ers version could not be verified (detected version: %s; required version: %s). The ERS integration may not work."):format(
+                detectedVersion,
+                ERS_MINIMUM_VERSION
+            ))
+            return
+        end
+
+        local comparisonOk, comparison = pcall(compareVersions, ERS_MINIMUM_VERSION, normalizedVersion)
+        if not comparisonOk or type(comparison) ~= "table" or type(comparison.result) ~= "boolean" then
+            errorLog("ERS_VERSION_TOO_OLD", ("The night_ers version could not be verified (detected version: %s; required version: %s). The ERS integration may not work."):format(
+                normalizedVersion,
+                ERS_MINIMUM_VERSION
+            ))
+            return
+        end
+
+        if comparison.result then
+            errorLog("ERS_VERSION_TOO_OLD", ("Detected night_ers version %s, but required version is %s or newer. The old version may cause the ERS integration not to work."):format(
+                normalizedVersion,
+                ERS_MINIMUM_VERSION
+            ))
+        end
+    end
+
     function startErs()
+        checkErsVersion()
         debugLog("Starting ERS Integration...")
         RegisterNetEvent('ErsIntegration::OnIsOfferedCallout')
         RegisterNetEvent('ErsIntegration::OnAcceptedCalloutOffer')


### PR DESCRIPTION
## Description

Adds a startup compatibility check to the ERS integration for the running `night_ers` resource.

- Reads the resource's `version` metadata.
- Requires ERS `1.8.16` or newer.
- Emits structured error `ERR-ERS-106` when ERS is older or its version cannot be verified.
- Keeps integration startup non-fatal after reporting the compatibility error.
- Documents the new error code and troubleshooting step.

## Motivation and Context

Older ERS versions may not provide the behavior expected by the SonoranCAD integration. Surfacing the detected and required versions gives server owners a clear compatibility diagnostic before they troubleshoot integration failures.

## How Has This Been Tested?

- Verified comparator boundaries: `1.8.15` reports too old; `1.8.16` and `1.9.0` do not.
- Parsed the added Lua block with `luaparse`.
- Ran `git diff-tree --check` successfully.
- Ran the structured logging audit; it reports only the pre-existing, unrelated `sonorancad/core/sonoran_api.lua:293` dynamic-key finding.
- Verified source/docs parity for `ERR-ERS-106`.

No live FXServer or `night_ers` runtime test was available, so live FiveM behavior remains to be confirmed.

## Contributor License Agreement

By submitting this pull request, you certify that you have read and agree to the project's Contributor License Agreement (CLA) under the PolyForm Noncommercial 1.0.0 license.

> I, **Jordan2139**, hereby agree to license my contributions to SonoranCADFiveM under the PolyForm Noncommercial License 1.0.0.

## Checklist

* [x] My code follows the project's coding style and conventions
* [x] I have updated documentation where necessary
* [x] I have read, signed, and agreed to the Contributor License Agreement (CLA)